### PR TITLE
Fixed naming of class in AdminMenu.cs

### DIFF
--- a/AdminMenu.cs
+++ b/AdminMenu.cs
@@ -1,4 +1,4 @@
-public static class Menu
+public static class AdminMenu
 {
     static int selectedOption = 0;
 


### PR DESCRIPTION
Renamed the class in AdminMenu.cs from 'Menu' to 'AdminMenu' to prevent naming ambiguity with the class inside of Menu.cs