### PR TITLE
Fixed wrong movie name display

### DIFF
--- a/ShowHandler.cs
+++ b/ShowHandler.cs
@@ -281,7 +281,7 @@ public static class ShowHandler
 
             // Confirm Selection
             Show show = moviesForDate[index];
-            Movie movie = MovieHandler.GetMovieById(show.Id)!;
+            Movie movie = MovieHandler.GetMovieById(show.MovieId)!;
             string confirmationMessage = $"Show Schedule\n\nMake a reservation for '{movie.Title}' on {show.DateString} at {show.StartTimeString}:";
             int selection = ConfirmSelection(show, movie, confirmationMessage);
             if (!(selection == 0))


### PR DESCRIPTION
Now the correct movie title is displayed to the user when in the movie schedule menu. Passed the show.Id to the method, instead of the show.MovieId